### PR TITLE
ML-51 Updated abiFilters

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,7 +52,8 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        ndk.abiFilters 'armeabi-v7a', 'arm64-v8a','x86_64'
+        targetSdkVersion 33
+        ndk.abiFilters 'arm64-v8a', 'armeabi-v7a'
         targetSdkVersion flutter.targetSdkVersion
         /// legacy material-lightmeter ap stopped updating after 60022
         /// 7xxxx means that it is a new app
@@ -91,6 +92,7 @@ android {
             signingConfig signingConfigs.release
             minifyEnabled true
             shrinkResources true
+            ndk.abiFilters 'arm64-v8a', 'armeabi-v7a'
         }
     }
 }


### PR DESCRIPTION
```
Fatal Exception: java.lang.RuntimeException: Unable to start activity ComponentInfo{com.vodemn.lightmeter/com.vodemn.lightmeter.MainActivity}: java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.lang.UnsatisfiedLinkError: dlopen failed: library "libflutter.so" not found
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4169)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4325)
       at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:101)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2574)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8757)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

Tried [this](https://stackoverflow.com/questions/75847901/google-play-store-library-libflutter-so-not-found-error) solution.